### PR TITLE
#39 - Removing main.spec

### DIFF
--- a/generators/server/templates/server/main.spec.js
+++ b/generators/server/templates/server/main.spec.js
@@ -1,7 +1,0 @@
-const {expect} = require('chai');
-
-describe('The main driver', () => {
-    it('starts up a web server', () => {
-        require('./main').then((result) => expect(result).to.be.an.object);
-    });
-});


### PR DESCRIPTION
Main.spec is starting up the app fully, which clashes with nodemon when you run `gulp develop`. Removing main.spec.
