### PR TITLE
Adding Browserify Shim

### DIFF
--- a/generators/client-angular/phases/writing.js
+++ b/generators/client-angular/phases/writing.js
@@ -13,5 +13,6 @@ module.exports = {
     );
     this.updateNpmScript('postinstall', 'npm run create-public-symlink');
     this.updateNpmScript('create-public-symlink', './scripts/npm/create-public-symlink.sh');
+    this.addBrowserifyShim('angular', 'global:angular');
   },
 };

--- a/generators/client-angular/templates/client/app.tpl.js
+++ b/generators/client-angular/templates/client/app.tpl.js
@@ -1,6 +1,7 @@
 /**
  * Assemble the Application Module
  */
+const angular = require('angular');
 const appModule = angular.module('<%= name %>', [
   // Third Party Modules
   'ui.router',

--- a/generators/client-angular/templates/client/app.tpl.js
+++ b/generators/client-angular/templates/client/app.tpl.js
@@ -3,7 +3,8 @@
  */
 const appModule = angular.module('<%= name %>', [
   // Third Party Modules
-  require('angular-ui-router'),
+  'ui.router',
+  'ngMaterial',
 
   // Application Modules
   'templates',

--- a/generators/client-angular/templates/client/index.tpl.jade
+++ b/generators/client-angular/templates/client/index.tpl.jade
@@ -6,11 +6,23 @@ head
   meta(name="viewport" content="width=device-width, initial-scale=1")
   link(rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" type='text/css')
   link(rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/animate.css/3.3.0/animate.min.css" type='text/css')
-  link(href='//fonts.googleapis.com/css?family=Roboto:100,300,400,500,700' rel='stylesheet' type='text/css')
+
   link(rel="stylesheet" href="/main.css")
+  link(rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/angular_material/0.11.0/angular-material.min.css")
+  link(rel="stylesheet" href='//fonts.googleapis.com/css?family=Roboto:100,300,400,500,700' type='text/css')
+  link(rel="stylesheet" href="//fonts.googleapis.com/icon?family=Material+Icons")
   link(rel="shortcut icon" href="assets/favicon.ico")
 
+
 body(ng-controller="ApplicationController")
+  script(src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.5/angular.min.js")
+  script(src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.5/angular-animate.min.js")
+  script(src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.5/angular-aria.min.js")
+  script(src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.5/angular-cookies.min.js")
+  script(src="//ajax.googleapis.com/ajax/libs/angular_material/0.11.0/angular-material.min.js")
+  script(src="//cdnjs.cloudflare.com/ajax/libs/angular-ui-router/0.2.15/angular-ui-router.js")
+  script(src="//cdnjs.cloudflare.com/ajax/libs/angular-material-icons/0.5.0/angular-material-icons.min.js")
+
   ui-view
   script(src="/app.js")
   //

--- a/generators/client-angular/templates/client/services/index.tpl.js
+++ b/generators/client-angular/templates/client/services/index.tpl.js
@@ -1,3 +1,4 @@
+const angular = require('angular');
 const index = angular.module('<%= name %>.services', []);
 index.service('NyanService', require('./nyan_service'));
 index.service('ConfigService', require('./config_service'));

--- a/generators/client-angular/templates/client/welcome/index.tpl.js
+++ b/generators/client-angular/templates/client/welcome/index.tpl.js
@@ -1,3 +1,4 @@
+const angular = require('angular');
 const index = angular.module('<%= name %>.welcome', [
   require('./nyan_cat/index').name,
 ]);

--- a/generators/client-angular/templates/client/welcome/nyan_cat/index.tpl.js
+++ b/generators/client-angular/templates/client/welcome/nyan_cat/index.tpl.js
@@ -1,3 +1,4 @@
+const angular = require('angular');
 const index = angular.module('<%= name %>.welcome.nyancat', []);
 
 // Nyan-Cat Directive Example

--- a/generators/client-angular/templates/client/welcome/welcome.static.jade
+++ b/generators/client-angular/templates/client/welcome/welcome.static.jade
@@ -1,2 +1,5 @@
-h1 Hello, {{ ctrl.target }}
-nyan-cat
+md-toolbar
+  h1 Hello, {{ ctrl.target }}
+md-content
+  md-card
+    nyan-cat

--- a/generators/client-build/phases/writing.js
+++ b/generators/client-build/phases/writing.js
@@ -4,6 +4,7 @@ module.exports = {
       'babelify',
       'mkdirp',
       'browserify',
+      'browserify-shim',
       'envify',
       'uglifyify',
       'watchify',

--- a/generators/client-build/templates/gulp/tasks/browserify_config.js.tpl
+++ b/generators/client-build/templates/gulp/tasks/browserify_config.js.tpl
@@ -12,6 +12,7 @@ module.exports = () => {
 <% if (client === 'angular') { %>
       ngHtml2Js(config.ngHtml2Js),
 <% } %>
+      'browserify-shim',
     ],
     debug: false,
     cache: {},

--- a/generators/client-react/phases/writing.js
+++ b/generators/client-react/phases/writing.js
@@ -1,5 +1,6 @@
 module.exports = {
   packageJson() {
     this.addDependency('react');
+    this.addBrowserifyShim('react', 'global:React');
   },
 };

--- a/generators/client-react/templates/client/app.js
+++ b/generators/client-react/templates/client/app.js
@@ -1,5 +1,5 @@
-const React = require('react/addons');
 const Application = require('./components/application');
+const React = require('react');
 
 window.onload = function onload() {
   // Facebook Authentication adds this value to the location hash

--- a/generators/client-react/templates/client/components/application.js
+++ b/generators/client-react/templates/client/components/application.js
@@ -1,4 +1,4 @@
-const React = require('react/addons');
+const React = require('react');
 
 const Application = React.createClass({
   render() {

--- a/generators/client-react/templates/client/index.tpl.jade
+++ b/generators/client-react/templates/client/index.tpl.jade
@@ -11,6 +11,7 @@ head
   link(rel="shortcut icon" href="assets/favicon.ico")
 
 body
+  script(src="//cdnjs.cloudflare.com/ajax/libs/react/0.13.3/react-with-addons.min.js")
   #app.app
   script(src="/app.js")
   //

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "body-parser": "^1.13.2",
     "browserify": "^11.0.0",
     "browserify-ng-html2js": "^1.1.2",
+    "browserify-shim": "^3.8.10",
     "chai": "^3.2.0",
     "codeclimate-test-reporter": "^0.1.0",
     "coffee-script": "^1.9.3",

--- a/util/common-generator/phases/initializing.js
+++ b/util/common-generator/phases/initializing.js
@@ -54,6 +54,10 @@ function addDevDependencies(...names) {
   names.forEach(this.addDevDependency);
 }
 
+function addBrowserifyShim(key, value) {
+  this.appendPackageJson({'browserify-shim': {[key]: value}});
+}
+
 /**
  * A private helper to update an NPM Script
  * @param name The name of the script section (e.g. postinstall, pretest)
@@ -88,6 +92,7 @@ module.exports = {
     this.addDependencies = addDependencies.bind(this);
     this.addDevDependencies = addDevDependencies.bind(this);
     this.updateNpmScript = updateNpmScript.bind(this);
+    this.addBrowserifyShim = addBrowserifyShim.bind(this);
   },
 
   scanPackageJson: function scanPackageJson() {


### PR DESCRIPTION
Common libraries that are commonly available over CDN should be loaded in separate script tags. This will minimize the size of the app bundle, allow the browser to parallelize script downloads, and take advantage of CDN providers' robust edge caching. 

Also, adding Material-Design libraries to the Angular client.

Fixes #78
