### PR TITLE
#91 - Update the Sass Task to Use the Glob in the Gulp Config

### DIFF
--- a/generators/client-styles/templates/gulp/tasks/sass.js
+++ b/generators/client-styles/templates/gulp/tasks/sass.js
@@ -3,10 +3,8 @@ const sass = require('gulp-sass');
 const lload = require('gulp-livereload');
 const config = require('../config');
 
-const STYLES_GLOB = 'client/styles/**/*.scss';
-
 gulp.task('sass', () => {
-  gulp.src(STYLES_GLOB)
+  gulp.src(config.client.styles)
     .pipe(sass().on('error', sass.logError))
     .pipe(gulp.dest(config.client.dist.path))
     .pipe(lload());

--- a/generators/gulp/templates/gulp/config.js.tpl
+++ b/generators/gulp/templates/gulp/config.js.tpl
@@ -16,7 +16,7 @@ module.exports = {
   all: sourceNode('all', '{client,server}'),
   build: ['gulpfile.js', 'gulp/**/*.js'],
   client: sourceNode('client', 'client', {
-    styles: ['client/styles/**/*.scss'],
+    styles: ['client/**/*.{scss,sass}'],
     staticJade: ['client/**/*.jade', '!client/**/*.dynamic.jade'],
     assets: ['client/assets/**/*.*'],
     html: ['client/**/*.html'],


### PR DESCRIPTION
Updating the Gulp Config so that it checks for Sass in the entire client dir.
Updating the Gulp Config so that it looks for .sass and .scss files

Fixes #91 
Fixes #92 
